### PR TITLE
Ice 3.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,16 @@ before_script:
 script:
 - docker run --rm -v $PWD/dist:/dist builder
 
-# Travis encryption:
+# Travis encryption where GITHUB_KEY is
+# a GitHub token with public_repo access
+# --------------------------------------
 # docker run -it --rm ruby bash
 # gem install travis
-# echo GITHUB_KEY | travis travis encrypt -r manics/zeroc-ice-py-centos7
+# travis encrypt -r openmicroscopy/zeroc-ice-py-centos7 $GITHUB_KEY
 deploy:
   provider: releases
   api_key:
-    secure: "h1CBz2BYYglFbtgGCdks9JBjtM07PZKBx7aSt7viatNTRSLkIA2E2OTYBFtmAs6MAoLnkGBWeNOGL/VvW2sQm+VMpmzUaXPyijrrFhPtwYZVIK0crKdXXC7ySflCFAVOLfb3GEZKXIltc0ARquSsgiI2uIh7PyMTQHb+BnGLP9GWjGdYpVDnnnx78pFE+3WynCZhIDK9DspuRkh+WGPmNb22UxUnLW5mPDgpO7uy5ct3ApDPdiczFJaTpUs3h3T3LtBxF13bZ5/f+uTK9DBeP0D1gDnGTdmb2ytxjBrEQubbtBf/SGKofuqzKovUO4Nnj2RFgFTYN6p0Vnw8hOxLnb7I8XUEjfa2G/jy8tlYYo5p/802RfTZfH+78luPuHBI5h6vZlQ9If1vflv6L04IQIPn0fGR4WQdkkMwIfuQGiTJAOuVpXJwCGTloq3zqgaW+vcwEYYDAMr2hlPcSly3WVHS7fQXeGcjyjd0wxbgKNRu+i7PMAQ8xeTtSZD+sMHg4K/iBG0O6EU1kyGqvgfiuORDvnJWVHv8oWTTU9KsjtQ4/Cd1S3B3MuH764Y9BayxJNl6pB8tyb2Ilg6I8dmMCLRs2dBXTjOegifXYaoLUInxSdGvLzF6SAAVZlwWBKRO5ybcsNi3iANlcWWHaXzPJcwV5ANqAFex2jUEqYuu+Pg="
+    secure: "MRAr8jfDQl5Bo4aZkp8lAq7g4XRZstKdVSqc5IACjj5WUrttenitd+qFSAGTlySLxItFQqa8KnzamULt/ImK0MAeV5RyhJc1qGusnToVFxyqvsDrG/p0Jn8A9a480F/KJLitM1J6uH0oKLTHqHnJewwgK+q1SK0V13jB5TaI/ZfscXWL+g7Zbir9Vo8pMOD1uEJAwGywEV1eOM5wItpsj6BmmZapvUCBArx+Gre3i4n5SIkA2BmOf9g0BCVBk8brL7gTN0orgol+DxFuNUJu8KzQEyRXhRpU9GlPi80E7OcO27SubrG7LdyfTnwWCxY8nn1zFk058641o2auzZKSZymZ3HPoDX38GwRloXTTBEHWUds/2ykQAHAJ9VmFbabE/BZq6xNUoM0mOxNhICe5aNNoJGKBgdS4Kgsar8xiZOfAKCUIzmiOjnw05c0xVoZmJtsibImsU0JWe7G9PxiPQh6DyLmHNT85yYp+RfTzoFNRUjzsPbGpDZGXWH/8On57f4l4YwcTowKnHwg6mqj5WA+EN4XO4DG7nHECUPVscMoj3oHwlvtVJ5hWcR3Yq/hVH0hNTKDeiNnWWx9xqhKrEhvOJHfx0JPfMsj+uNey3XiEGuhFOVaMy14pEcTOCPmzI7yq5NRszgFy8lu/eqN1lGgTItfJHO5v5BFScZ7zyc8="
   file_glob: true
   file: dist/zeroc*
   skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-RUN curl -sL https://zeroc.com/download/rpm/el7/zeroc-ice-el7.repo > \
-    /etc/yum.repos.d/zeroc-ice-el7.repo
+RUN curl -sL https://zeroc.com/download/Ice/3.6/el7/zeroc-ice3.6.repo > \
+    /etc/yum.repos.d/zeroc-ice3.6.repo
 RUN yum install -y -q epel-release && \
     yum install -y -q \
         ice-all-runtime \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN yum install -y -q epel-release && \
 RUN pip install wheel
 RUN mkdir /dist
 ADD build.sh /
-CMD ["/build.sh", "3.6.3"]
+CMD ["/build.sh", "3.6.4"]


### PR DESCRIPTION
Updates the config to build IcePy 3.6.4.

To get this [released](https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases) a separate PR will be required to update the secret deploy key in https://github.com/openmicroscopy/zeroc-ice-py-centos7/blob/0.0.2/.travis.yml#L20 