### PR TITLE
Switch to Python 3 and Ice 3.6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN yum install -y -q epel-release && \
         gcc-c++ \
         libdb-utils \
         openssl-devel \
-        python-devel \
-        python-pip \
+        python3 \
+        python3-devel \
+        python3-wheel \
         rpm-build
-RUN pip install wheel
 RUN mkdir /dist
 ADD build.sh /
 CMD ["/build.sh", "3.6.4"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN yum install -y -q epel-release && \
         rpm-build
 RUN mkdir /dist
 ADD build.sh /
-CMD ["/build.sh", "3.6.4"]
+CMD ["/build.sh", "3.6.5"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN yum install -y -q epel-release && \
         openssl-devel \
         python3 \
         python3-devel \
-        python3-wheel \
-        rpm-build
+        python3-wheel
 RUN mkdir /dist
 ADD build.sh /
 CMD ["/build.sh", "3.6.5"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Centos 7 Zeroc Ice Python Builder
-=================================
+Centos 7 Zeroc Ice Python 3 Builder
+===================================
 
-Builds Zeroc Ice wheel and RPM Python packages for CentOS 7.
+Builds Zeroc Ice wheel and RPM Python 3 packages for CentOS 7.
 
 This can be used to create installable binary packages as an alternative to compiling from source using pip.
 

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 set -eu
 
 ICE_VERSION="$1"
-pip download "zeroc-ice==$ICE_VERSION"
+pip3 download "zeroc-ice==$ICE_VERSION"
 tar -zxf "zeroc-ice-$ICE_VERSION.tar.gz"
 cd "zeroc-ice-$ICE_VERSION"
-python setup.py bdist_wheel bdist_rpm
+python3 setup.py bdist_wheel bdist_rpm
 cp dist/* /dist/

--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,5 @@ ICE_VERSION="$1"
 pip3 download "zeroc-ice==$ICE_VERSION"
 tar -zxf "zeroc-ice-$ICE_VERSION.tar.gz"
 cd "zeroc-ice-$ICE_VERSION"
-python3 setup.py bdist_wheel bdist_rpm
+python3 setup.py bdist_wheel
 cp dist/* /dist/


### PR DESCRIPTION
Testing:
```
docker pull centos:7
```
```
docker build -t builder .
docker run --rm -v $PWD/dist:/dist builder
```
```
docker run -it --rm -v $PWD/dist:/dist:ro centos:7
yum install python3
python3 -mvenv venv
venv/bin/pip install /dist/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
venv/bin/python -c 'import Ice; print(Ice.stringVersion())'
```
Should also work without a virtualenv

Tag: `0.2.0`

Example use: https://github.com/ome/ansible-role-omero-web/pull/26/files#diff-075c3414f6392b9af5513f79544bb733R82